### PR TITLE
Fix typo

### DIFF
--- a/usr/bin/serene-startdash
+++ b/usr/bin/serene-startdash
@@ -202,8 +202,8 @@ function show_version () {
         --info \
         --width="600" \
         --height="100" \
-        --text="＝＝　EG-Intaler　＝＝\nVersion:　${version}\nYamada　Hayao　shun819.mail@gmail.com"
-    debug_msg "EG-installer v${version}"
+        --text="＝＝　EG-Installer　＝＝\nVersion:　${version}\nYamada　Hayao　shun819.mail@gmail.com"
+    debug_msg "EG-Installer v${version}"
     exit 0
 }
 


### PR DESCRIPTION
誤字修正しました
`EG-Intaler` → `EG-Installer`
あとデバッグメッセージの`EG-installer`も`EG-Installer`にしました(他の表記は`i`が大文字だったため)

(https://github.com/Hayao0819/EG-Installer/pull/5 と同じです)